### PR TITLE
Update torch to version 2.0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['numpy==1.23.0', 'protobuf==4.21.2', 'requests==2.28.0', 'torch==1.12.0', 'tqdm==4.62.3', 'obeliks==1.1.6', 'reldi-tokeniser==1.0.2'],
+    install_requires=['numpy==1.23.0', 'protobuf==4.21.2', 'requests==2.28.0', 'torch==2.0.1', 'tqdm==4.62.3', 'obeliks==1.1.6', 'reldi-tokeniser==1.0.2'],
 
     # List required Python versions
     python_requires='>=3.6',

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['numpy==1.23.0', 'protobuf==4.21.2', 'requests==2.28.0', 'torch==2.0.1', 'tqdm==4.62.3', 'obeliks==1.1.6', 'reldi-tokeniser==1.0.2'],
+    install_requires=['numpy==1.23.0', 'protobuf==4.21.2', 'requests==2.28.0', 'torch==2.1.0', 'tqdm==4.62.3', 'obeliks==1.1.6', 'reldi-tokeniser==1.0.2'],
 
     # List required Python versions
     python_requires='>=3.6',


### PR DESCRIPTION
## Desciption
The current torch version supports CUDA version 10.2, which supports CUDA capabilities up to `sm_70`. Newer GPUs are not supported. The PR upgrades `torch` version to 2.0.2, allowing the use of newer GPUs.
